### PR TITLE
Update for Styled Components v4.0+

### DIFF
--- a/lib/WindowSize.js
+++ b/lib/WindowSize.js
@@ -1,0 +1,192 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _utils = require('./utils');
+
+var _THEME2 = require('./THEME');
+
+var _THEME3 = _interopRequireDefault(_THEME2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(function () {
+  var enterModule = require('react-hot-loader').enterModule;
+
+  enterModule && enterModule(module);
+})();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var MEDIA_DEFAULT = 'xs';
+
+function getCurrentMedia(ranges) {
+  var width = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+
+  var media = MEDIA_DEFAULT;
+  Object.keys(ranges).some(function (key) {
+    var _ranges$key = _slicedToArray(ranges[key], 2),
+        min = _ranges$key[0],
+        max = _ranges$key[1];
+
+    if (width >= min && width <= max) {
+      media = key;
+      return true;
+    }
+    return false;
+  });
+  return media;
+}
+
+function getWindowSize() {
+  var width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+  var height = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
+  return { width: width, height: height };
+}
+
+/**
+ * WindowSize
+ *
+ * Wrapper component to supply current 'window' sizing and 'media' breakpoint to the wrapped component
+ * Value of 'media' will be one of: 'xs' (default), 'sm', 'md', 'lg', 'xl'
+ * Supports "children as a function"
+ */
+var propTypes = {
+  children: _propTypes2.default.oneOfType([_propTypes2.default.node, _propTypes2.default.func]).isRequired,
+  theme: _propTypes2.default.object // optional theme media overrides
+};
+
+var WindowSize = function (_React$Component) {
+  _inherits(WindowSize, _React$Component);
+
+  function WindowSize(props) {
+    _classCallCheck(this, WindowSize);
+
+    var _this = _possibleConstructorReturn(this, (WindowSize.__proto__ || Object.getPrototypeOf(WindowSize)).call(this, props));
+
+    _this.handleResize = function () {
+      var _getWindowSize = getWindowSize(),
+          width = _getWindowSize.width,
+          height = _getWindowSize.height;
+
+      var media = getCurrentMedia(_this.mediaRanges, width);
+      _this.setState({ width: width, height: height, media: media });
+    };
+
+    _this.state = {
+      media: MEDIA_DEFAULT,
+      height: 0,
+      width: 0
+    };
+
+    var _THEME = _extends({}, _THEME3.default, props.theme || {}),
+        MEDIA_SM = _THEME.MEDIA_SM,
+        MEDIA_MD = _THEME.MEDIA_MD,
+        MEDIA_LG = _THEME.MEDIA_LG,
+        MEDIA_XL = _THEME.MEDIA_XL;
+
+    _this.mediaRanges = {
+      xs: [0, MEDIA_SM - 1],
+      sm: [MEDIA_SM, MEDIA_MD - 1],
+      md: [MEDIA_MD, MEDIA_LG - 1],
+      lg: [MEDIA_LG, MEDIA_XL - 1],
+      xl: [MEDIA_XL, Infinity]
+    };
+    return _this;
+  }
+
+  _createClass(WindowSize, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      if (window) {
+        (0, _utils.throttleEvent)('resize', 'throttledWindowResize', window);
+        window.addEventListener('throttledWindowResize', this.handleResize);
+        this.handleResize();
+      }
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      if (window) {
+        window.removeEventListener('throttledWindowResize', this.handleResize);
+      }
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var children = this.props.children;
+      var _state = this.state,
+          width = _state.width,
+          height = _state.height,
+          media = _state.media;
+
+
+      var windowProps = {
+        media: media,
+        window: { width: width, height: height }
+      };
+
+      if (typeof children === 'function') {
+        return children(windowProps);
+      }
+
+      return _react2.default.Children.map(children, function (child) {
+        return _react2.default.cloneElement(child, windowProps);
+      });
+    }
+  }, {
+    key: '__reactstandin__regenerateByEval',
+    // @ts-ignore
+    value: function __reactstandin__regenerateByEval(key, code) {
+      // @ts-ignore
+      this[key] = eval(code);
+    }
+  }]);
+
+  return WindowSize;
+}(_react2.default.Component);
+
+WindowSize.propTypes = propTypes;
+var _default = WindowSize;
+exports.default = _default;
+;
+
+(function () {
+  var reactHotLoader = require('react-hot-loader').default;
+
+  var leaveModule = require('react-hot-loader').leaveModule;
+
+  if (!reactHotLoader) {
+    return;
+  }
+
+  reactHotLoader.register(MEDIA_DEFAULT, 'MEDIA_DEFAULT', 'src/lib/WindowSize.js');
+  reactHotLoader.register(getCurrentMedia, 'getCurrentMedia', 'src/lib/WindowSize.js');
+  reactHotLoader.register(getWindowSize, 'getWindowSize', 'src/lib/WindowSize.js');
+  reactHotLoader.register(propTypes, 'propTypes', 'src/lib/WindowSize.js');
+  reactHotLoader.register(WindowSize, 'WindowSize', 'src/lib/WindowSize.js');
+  reactHotLoader.register(_default, 'default', 'src/lib/WindowSize.js');
+  leaveModule(module);
+})();
+
+;

--- a/package.json
+++ b/package.json
@@ -34,13 +34,11 @@
     "prepublishOnly": "npm run dist",
     "test": "jest --watch --no-cache"
   },
-  "dependencies": {
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
-    "react-hot-loader": "^4.3.3",
-    "styled-components": "^3.3.3"
-  },
   "devDependencies": {
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3",
+    "react-hot-loader": "^4.3.3",
+    "styled-components": "^4.1.2",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.5",
@@ -75,8 +73,9 @@
     "webpack-dev-server": "3.1.4"
   },
   "peerDependencies": {
-    "react": ">= 15.0",
-    "styled-components": ">= 2.2.0"
+    "react": ">= 16.0",
+    "react-dom": ">= 16.0",
+    "styled-components": ">= 4.0"
   },
   "lint-staged": {
     "src/**/*.js": [

--- a/src/demoData.js
+++ b/src/demoData.js
@@ -1,26 +1,31 @@
 import React from 'react';
-import { css } from 'styled-components';
+import styled, { css } from 'styled-components';
 import * as Components from './lib/index';
+
+export const Code = styled.code`
+  color: ${props => props.color || 'firebrick'};
+  font-size: 1.6rem;
+`;
 
 const TYPES = {
   ARRAY: 'Array',
   BOOL: 'Boolean',
-  BOOL_OR_NUMBER: 'Boolean, Number',
-  BOOL_OR_STRING: 'Boolean, String',
-  FUNC: 'Function',
+  BOOL_OR_NUMBER: 'Boolean|Number',
+  BOOL_OR_STRING: 'Boolean|String',
+  FUNC: 'Function|Object',
+  FUNC_OR_OBJECT: 'Function|Object',
   NODE: 'React Elem(s)',
   NUMBER: 'Number',
-  NUMBER_OR_OBJECT: 'Number, Object',
+  NUMBER_OR_OBJECT: 'Number|Object',
   OBJECT: 'Object',
   STRING: 'String',
-  STRING_OR_NUMBER: 'String, Number',
-  STRING_OR_ARRAY_OF_CSS: 'String, Array (css)',
-  STYLES: 'String, Array (css), Object',
+  STRING_OR_NUMBER: 'String|Number',
+  STRING_OR_ARRAY_OF_CSS: 'String|Array (css)',
+  STYLES: 'String|Array (css)|Object',
 };
 
 const PROP_TYPES = {
   children: TYPES.NODE,
-  innerRef: TYPES.FUNC,
   theme: TYPES.OBJECT,
 
   hide: TYPES.BOOL,
@@ -74,12 +79,6 @@ const PROP_TYPES = {
   center: TYPES.BOOL,
   right: TYPES.BOOL,
 
-  h1: TYPES.BOOL,
-  h2: TYPES.BOOL,
-  h3: TYPES.BOOL,
-  h4: TYPES.BOOL,
-  h5: TYPES.BOOL,
-
   flexDirection: TYPES.STRING,
   flexWrap: TYPES.STRING,
   justifyContent: TYPES.STRING,
@@ -103,6 +102,7 @@ const PROP_TYPES = {
   colorTo: TYPES.STRING,
   height: TYPES.STRING_OR_NUMBER,
 
+  innerRef: TYPES.FUNC_OR_OBJECT,
   width: TYPES.STRING_OR_NUMBER,
   stroke: TYPES.STRING_OR_NUMBER,
   inset: TYPES.STRING_OR_NUMBER,
@@ -226,9 +226,13 @@ const DEMO = {
   },
 
   HEADING: {
-    DESCRIPTION: 'Renders H1, H2, H3, H4, or H5 tag.',
+    DESCRIPTION: (
+      <span>
+        Renders H1 tag. Use the <Code>as</Code> prop to apply H2, H3...
+      </span>
+    ),
     CODE: `
-<Heading h2 center color="gold" margin={0} normal underline xxLarge>
+<Heading as="h2" center color="gold" margin={0} normal underline xxLarge>
 	Super Styled
 </Heading>`,
   },

--- a/src/lib/Heading.js
+++ b/src/lib/Heading.js
@@ -19,11 +19,6 @@ import {
  */
 const propTypes = {
   ...basePropTypes,
-  h1: PropTypes.bool,
-  h2: PropTypes.bool,
-  h3: PropTypes.bool,
-  h4: PropTypes.bool,
-  h5: PropTypes.bool,
   color: PropTypes.string,
   lineHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   margin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -32,9 +27,9 @@ const propTypes = {
   ...mediaStylesPropTypes,
 };
 
-const getCss = props => {
+const getCss = props =>
   // prettier-ignore
-  return css`
+  css`
     color: ${props.color};
     line-height: ${props.lineHeight};
     ${props.margin !== undefined && cssSpacing('margin', props)} 
@@ -42,43 +37,10 @@ const getCss = props => {
     ${withJustify(props)}
     ${withMediaStyles(props)}
   `;
-};
 
-const Heading1 = styled.h1`
+const Heading = styled.h1`
   ${props => getCss(addTheme(props))};
 `;
-
-const Heading2 = styled.h2`
-  ${props => getCss(addTheme(props))};
-`;
-
-const Heading3 = styled.h3`
-  ${props => getCss(addTheme(props))};
-`;
-
-const Heading4 = styled.h4`
-  ${props => getCss(addTheme(props))};
-`;
-
-const Heading5 = styled.h5`
-  ${props => getCss(addTheme(props))};
-`;
-
-const Heading = props => {
-  const hTag = ['h1', 'h2', 'h3', 'h4', 'h5'].find(hTag => hTag in props);
-  switch (hTag) {
-    case 'h5':
-      return <Heading5 {...props}>{props.children}</Heading5>;
-    case 'h4':
-      return <Heading4 {...props}>{props.children}</Heading4>;
-    case 'h3':
-      return <Heading3 {...props}>{props.children}</Heading3>;
-    case 'h2':
-      return <Heading2 {...props}>{props.children}</Heading2>;
-    default:
-      return <Heading1 {...props}>{props.children}</Heading1>;
-  }
-};
 
 Heading.propTypes = propTypes;
 export default Heading;

--- a/src/lib/SvgIcon.js
+++ b/src/lib/SvgIcon.js
@@ -108,6 +108,7 @@ const Svg = styled.svg`
 const propTypes = {
   // basic svg
   ...basePropTypes,
+  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   color: PropTypes.string,
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -137,6 +138,7 @@ const defaultProps = {
 const SvgIcon = props => {
   props = addTheme(props);
   let {
+    innerRef,
     inset,
     offsetX,
     offsetY,
@@ -148,7 +150,6 @@ const SvgIcon = props => {
     onClick,
     stroke,
     viewBox,
-    innerRef,
     styles,
     ...attribs
   } = props;
@@ -165,7 +166,7 @@ const SvgIcon = props => {
     return (
       <BasicSvg
         {...attribs}
-        innerRef={innerRef}
+        ref={innerRef}
         height={heightPx}
         width={widthPx}
         viewBox={viewBox}
@@ -201,7 +202,7 @@ const SvgIcon = props => {
   return (
     <Wrapper
       {...attribs}
-      innerRef={innerRef}
+      ref={innerRef}
       outerHeight={heightUnits}
       outerWidth={widthUnits}
       styles={styles}

--- a/src/lib/WindowSize.js
+++ b/src/lib/WindowSize.js
@@ -87,7 +87,7 @@ export default class WindowSize extends React.Component {
 
     const windowProps = {
       media,
-      window: { width, height },
+      windowSize: { width, height },
     };
 
     if (typeof children === 'function') {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -134,7 +134,6 @@ export function throttleEvent(type, name, obj) {
 
 const basePropTypes = {
   children: PropTypes.node,
-  innerRef: PropTypes.func,
   theme: PropTypes.object,
 };
 export { basePropTypes };

--- a/src/lib/withWindow.js
+++ b/src/lib/withWindow.js
@@ -69,7 +69,11 @@ const withWindow = (EnhancedComponent, userTheme = {}) => {
 
     render() {
       return (
-        <EnhancedComponent media={this.state.media} window={this.state.window} {...this.props} />
+        <EnhancedComponent
+          media={this.state.media}
+          windowSize={this.state.window}
+          {...this.props}
+        />
       );
     }
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,12 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-annotate-as-pure@^7.0.0-beta.37":
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.51.tgz#38cf7920bf5f338a227f754e286b6fbadee04b58"
@@ -105,6 +111,28 @@
     esutils "^2.0.2"
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.0.0":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.6.tgz#0adb330c3a281348a190263aceb540e10f04bcce"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@emotion/is-prop-valid@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
+  dependencies:
+    "@emotion/memoize" "^0.6.6"
+
+"@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -785,6 +813,14 @@ babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.9.2.tgz#0e6a6587454dcb1c9a362a8fd31fc0b075ccd260"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.10"
+
 babel-plugin-styled-components@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.5.1.tgz#31dbeb696d1354d1585e60d66c7905f5e474afcd"
@@ -837,7 +873,7 @@ babel-plugin-syntax-function-bind@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz#48c495f177bdf31a981e732f55adc0bdd2601f46"
 
-babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
@@ -1524,13 +1560,6 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.3:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -2043,9 +2072,9 @@ css-select@^1.1.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-to-react-native@^2.0.3:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.1.tgz#7f3f4c95de65501b8720c87bf0caf1f39073b88e"
+css-to-react-native@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
   dependencies:
     css-color-keywords "^1.0.0"
     fbjs "^0.8.5"
@@ -2920,7 +2949,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.5:
+fbjs@^0.8.5:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -4719,6 +4748,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memoize-one@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.3.tgz#cdfdd942853f1a1b4c71c5336b8c49da0bf0273c"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -5606,7 +5639,7 @@ prompts@^0.1.9:
     clorox "^1.0.3"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -5739,14 +5772,14 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@^16.6.3:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    scheduler "^0.11.2"
 
 react-hot-loader@^4.3.3:
   version "4.3.3"
@@ -5759,9 +5792,9 @@ react-hot-loader@^4.3.3:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
 
-react-is@^16.3.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
+react-is@^16.6.0:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -5778,14 +5811,14 @@ react-live@^1.10.1:
     prop-types "^15.5.8"
     unescape "^0.2.0"
 
-react@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+react@^16.6.3:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    scheduler "^0.11.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -6140,6 +6173,13 @@ sane@^2.0.0:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+scheduler@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "0.4.5"
@@ -6633,20 +6673,20 @@ strip-url-auth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
 
-styled-components@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.3.3.tgz#09e702055ab11f7a8eab8229b1c0d0b855095686"
+styled-components@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.2.tgz#f8a685e3b2bcd03c5beac7f2c02bb6ad237da9b3"
   dependencies:
-    buffer "^5.0.3"
-    css-to-react-native "^2.0.3"
-    fbjs "^0.8.16"
-    hoist-non-react-statics "^2.5.0"
-    is-plain-object "^2.0.1"
+    "@emotion/is-prop-valid" "^0.6.8"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
     prop-types "^15.5.4"
-    react-is "^16.3.1"
+    react-is "^16.6.0"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
-    supports-color "^3.2.3"
+    supports-color "^5.5.0"
 
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
@@ -6660,7 +6700,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -6669,6 +6709,12 @@ supports-color@^3.1.2, supports-color@^3.2.3:
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
* Bump SC peer dependency to >= 4.0
* Simplify `Heading`, no longer supports `h2, h3, ...` props (use `as="h2"` instead)
* Rename `window` prop to `windowSize` in `WindowSize` (and `withWindow` HOC)
